### PR TITLE
Trying cordova-plugin-cocoapod-support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "cordova-plugin-cocoapod-support": "1.6.2",
     "cordova-common": "^3.2.0",
     "cordova-js": "^5.0.0",
     "cordova-lib": "^9.0.1",

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@
     <!-- pod tag is a cordova-plugin-cocoapod-support thing -->
     <pod name="TrueTime" version="5.0.3" />
     <!--
-    Because cordova support of cocoapods only exists to, putting it nicely, torment developers I found alternative solutions.
+    Due to some troubles with podspec/framework tags, trying cordova-plugin-cocoapod-support for cocoapod dependencies.
     <podspec>
       <config>
         <source url="https://github.com/CocoaPods/Specs.git"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -12,6 +12,8 @@
   </js-module>
 
   <platform name="ios">
+    <dependency id="cordova-plugin-cocoapod-support" version="1.6.2" />
+
     <config-file target="config.xml" parent="/*">
       <feature name="Date">
         <param name="ios-package" value="CDVDate"/>
@@ -21,6 +23,11 @@
     <header-file src="src/ios/CDVDate.h" />
     <source-file src="src/ios/CDVDate.m" />
     <source-file src="src/ios/DateSwiftHack.swift" />
+
+    <!-- pod tag is a cordova-plugin-cocoapod-support thing -->
+    <pod name="TrueTime" version="5.0.3" />
+    <!--
+    Because cordova support of cocoapods only exists to, putting it nicely, torment developers I found alternative solutions.
     <podspec>
       <config>
         <source url="https://github.com/CocoaPods/Specs.git"/>
@@ -30,6 +37,7 @@
       </pods>
     </podspec>
     <framework src="TrueTime" type="podspec" spec="~> 5.0.3" />
+     -->
   </platform>
   
   <platform name="android">


### PR DESCRIPTION
The plugin orginally uses podspec/framework tags to include cocoapods. This is how cordova supports them; but, it seems to be unreliable. Problems happen etc.

The cocoapod support plugin was as a easy as specify the dependency and use their pod tag. From there it just worked. So far it looks very easy to use and has been a smooth experience.