### PR TITLE
Fix native not successfully initializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 0.0.5-dev
 - [#12](https://github.com/totalpave/cordova-plugin-date/pull/12) - (Android) Upgraded TrueTime back to `3.4`. Omit `withSharedPreferences` configuration.
 - [#13](https://github.com/totalpave/cordova-plugin-date/pull/13) - (iOS) Avoid potential crash in iOS
-- Updated JS to detect when the native side and automatically call `_reinit` and `update` until an TrueTime value can be obtained.
-- (iOS) Updated to not go across the cordova bridge during `_reinit`. As of [#13](https://github.com/totalpave/cordova-plugin-date/pull/13), iOS `_reinit` does nothing.
+- Updated JS to detect when the native side has not properly initiated and automatically call `_reinit` and `update` until an TrueTime value can be obtained.
+- (iOS) Updated `_reinit` to not go across the cordova bridge on iOS devices. As of [#13](https://github.com/totalpave/cordova-plugin-date/pull/13), iOS `_reinit` does nothing.
 
 
 ## 0.0.4 (November 18, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.0.5-dev
 - [#12](https://github.com/totalpave/cordova-plugin-date/pull/12) - (Android) Upgraded TrueTime back to `3.4`. Omit `withSharedPreferences` configuration.
 - [#13](https://github.com/totalpave/cordova-plugin-date/pull/13) - (iOS) Avoid potential crash in iOS
+- Updated JS to detect when the native side and automatically call `_reinit` and `update` until an TrueTime value can be obtained.
+- (iOS) Updated to not go across the cordova bridge during `_reinit`. As of [#13](https://github.com/totalpave/cordova-plugin-date/pull/13), iOS `_reinit` does nothing.
+
 
 ## 0.0.4 (November 18, 2019)
 - [#9](https://github.com/totalpave/cordova-plugin-date/pull/9) - (Android) Downgraded TrueTime to `3.2`

--- a/www/date.js
+++ b/www/date.js
@@ -54,7 +54,11 @@ var date = {
    },
    _startInitErrorInterval: function() {
       if (!date._initErrorInterval) {
-         date._initErrorInterval = window.setInterval(() => {
+         // We're using recursive function that setups timeouts so that we can 
+         // avoid having the asynchronous code pile up with an interval.
+         // The timeout is still setup like an interval as it will keep on re-doing the timeout until
+         // The asynchronous code comes back successful.
+         date._initErrorInterval = window.setTimeout(() => {
             new Promise((resolve, reject) => {
                date._reinit(resolve, reject);
             }).then(() => {
@@ -62,9 +66,11 @@ var date = {
                   date.update(resolve, reject);
                });
             }).then(() => {
-               window.clearInterval(date._initErrorInterval);
                date._initErrorInterval = null;
-            }).catch(date._logger.log);
+            }).catch((error) => {
+               date._logger.log(error);
+               this._startInitErrorInterval();
+            });
          }, INIT_ERROR_INTERVAL_DELAY);
       }
    },

--- a/www/date.js
+++ b/www/date.js
@@ -41,7 +41,6 @@ var date = {
    _logger: console,
    _difference: null,
    ERRORS: ERRORS,
-   _updateErrorInterval: null,
    _updateInterval: null,
    _initErrorInterval: null,
    _hasCalledInit: false,

--- a/www/date.js
+++ b/www/date.js
@@ -85,7 +85,12 @@ var date = {
       }
    },
    reinit: function(success, fail) {
+      // So iOS can't really run reinit. 
+      // iOS TrueTime seems to always initialize properly, even if there is no internet. When there is internet, update will simply work.
+      // If you tried to reinit it would actually cause an exception. So the native code was updated to not doing anything on reinit.
+      // Since the native code doesn't do anything on reinit, let's just not go over the cordova bridge.  
       if (cordova.platformId === PLATFORMS.IOS) {
+         // Keep the function flow asynchronous with this timeout.
          window.setTimeout(() => {
             success();
          });

--- a/www/date.js
+++ b/www/date.js
@@ -74,7 +74,7 @@ var date = {
       if (!date._initErrorInterval) {
          date._initErrorInterval = window.setInterval(() => {
             new Promise((resolve, reject) => {
-               date.reinit(() => {
+               date._reinit(() => {
                   date.update(resolve, reject);
                }, reject);
             }).then(() => {
@@ -84,7 +84,7 @@ var date = {
          }, INIT_ERROR_INTERVAL_DELAY);
       }
    },
-   reinit: function(success, fail) {
+   _reinit: function(success, fail) {
       // So iOS can't really run reinit. 
       // iOS TrueTime seems to always initialize properly, even if there is no internet. When there is internet, update will simply work.
       // If you tried to reinit it would actually cause an exception. So the native code was updated to not doing anything on reinit.


### PR DESCRIPTION
Fixes issue https://github.com/totalpave/cordova-plugin-date/issues/10

On Android, if the plugin initializes without internet; then, the plugin does not initialize properly and we need to call _reinit and update (to get the new time difference). 
On iOS, even if the plugin is initialized without internet, the plugin initializes correctly; but, on iOS calling _reinit does nothing. So all we need to do is call update when we have internet.

The changes are setup so both iOS and Android runs through the same code path. iOS won't actually go across the cordova bridge when calling _reinit; but, it will still call the function. 