### PR TITLE
Updated TrueTime dependency to use cordova ios 6 system.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -12,7 +12,6 @@
   </js-module>
 
   <platform name="ios">
-    <dependency id="cordova-plugin-cocoapod-support" version="1.6.2" />
 
     <config-file target="config.xml" parent="/*">
       <feature name="TPDate">
@@ -24,20 +23,11 @@
     <source-file src="src/ios/CDVTPDate.m" />
     <source-file src="src/ios/DateSwiftHack.swift" />
 
-    <!-- pod tag is a cordova-plugin-cocoapod-support thing -->
-    <pod name="TrueTime" version="5.0.3" />
-    <!--
-    Due to some troubles with podspec/framework tags, trying cordova-plugin-cocoapod-support for cocoapod dependencies.
     <podspec>
-      <config>
-        <source url="https://github.com/CocoaPods/Specs.git"/>
-      </config>
       <pods>
-        <pod name="TrueTime" spec="5.0.3"/>
+        <pod name="TrueTime" git="git@github.com:instacart/TrueTime.swift.git" tag="5.1.0"/>
       </pods>
     </podspec>
-    <framework src="TrueTime" type="podspec" spec="~> 5.0.3" />
-     -->
   </platform>
   
   <platform name="android">


### PR DESCRIPTION
The pod is pointing at a git url because we need to use TrueTime 5.1.0.

The cocoapods TrueTime version is 5.0.3, which was built with Swift 3.x. Apparently XCode 11.x-13.x has completely dropped support for Swift 3.x. I would have to downgrade to Xcode 10.1.x.

Instead, TrueTime does have a 5.1.0 release but it's not in the cocoapods. You need to reference their github repo.